### PR TITLE
Fix game state destructor

### DIFF
--- a/src/GameState/GameState.cpp
+++ b/src/GameState/GameState.cpp
@@ -60,8 +60,9 @@ GameState::GameState() {
 
 GameState::~GameState() {
   if (map) {
-    delete map;
-    map = NULL;
+      Map::resetMapInstance();
+//    delete map;
+//    map = NULL;
   }
   if (players) {
     delete players;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,14 @@
 #include "Map/MapDriver.h"
 #include "PlayerStrategies/PlayerStrategiesDriver.h"
+#include "Map/Map.h"
 
 int main()
 {
     //// Assignment 3 Drivers ////
 
     // Part 1)
-    playerStrategiesDriver();
+//    playerStrategiesDriver();
+//    Map::resetMapInstance();
 
     // Part 2)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,17 +7,20 @@ int main()
 {
     //// Assignment 3 Drivers ////
 
-    // NOTE TO GRADERS: Run each driver at a time, they will not run consecutively
-
     // Part 1)
     playerStrategiesDriver();
+
+    // Clear state between drivers
     Map::resetMapInstance();
 
     // Part 2) and 3)
-    // gameObserversDriver();
+    gameObserversDriver();
+
+    // Clear state between drivers
+    Map::resetMapInstance();
 
     // Part 4)
-    // mapSingletonTest();
+    mapSingletonTest();
 
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,8 +7,8 @@ int main()
     //// Assignment 3 Drivers ////
 
     // Part 1)
-//    playerStrategiesDriver();
-//    Map::resetMapInstance();
+    playerStrategiesDriver();
+    Map::resetMapInstance();
 
     // Part 2)
 


### PR DESCRIPTION
I just fix bugs in ~GameState( ) and resetMapInstance( ) after or before each drivers,
now they can run one by one
 @mdesson @seanheinrichs 